### PR TITLE
✨ Add support to rmdir operation 

### DIFF
--- a/library/std/src/sys/hermit/fs.rs
+++ b/library/std/src/sys/hermit/fs.rs
@@ -531,8 +531,8 @@ pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
     match perm.0 {}
 }
 
-pub fn rmdir(_p: &Path) -> io::Result<()> {
-    unsupported()
+pub fn rmdir(path: &Path) -> io::Result<()> {
+    run_path_with_cstr(path, |path| cvt(unsafe { abi::rmdir(path.as_ptr()) }).map(|_| ()))
 }
 
 pub fn remove_dir_all(_path: &Path) -> io::Result<()> {


### PR DESCRIPTION
This PR adds support to the rmdir operation and closes issue #3.

This change is related to the other two PRs listed below:

- https://github.com/simonschoening/rusty-hermit/pull/1
- https://github.com/simonschoening/libhermit-rs/pull/6