### PR TITLE
✨ Add support for the mkdir operation

### DIFF
--- a/library/std/src/sys/hermit/fs.rs
+++ b/library/std/src/sys/hermit/fs.rs
@@ -93,7 +93,9 @@ impl core::hash::Hash for FileType {
 }
 
 #[derive(Debug)]
-pub struct DirBuilder {}
+pub struct DirBuilder {
+    mode: u32,
+}
 
 impl FileAttr {
     pub fn size(&self) -> u64 {
@@ -452,11 +454,15 @@ impl File {
 
 impl DirBuilder {
     pub fn new() -> DirBuilder {
-        DirBuilder {}
+        DirBuilder { mode: 0o777 }
     }
 
-    pub fn mkdir(&self, _p: &Path) -> io::Result<()> {
-        unsupported()
+    pub fn mkdir(&self, path: &Path) -> io::Result<()> {
+        run_path_with_cstr(path, |path| cvt(unsafe { abi::mkdir(path.as_ptr(), self.mode) }).map(|_| ()))
+    }
+
+    pub fn set_mode(&mut self, mode: u32) {
+        self.mode = mode as u32;
     }
 }
 


### PR DESCRIPTION
This PR adds support for the mkdir operation in hermit.

This change is related to the other two PRs listed below:

- https://github.com/simonschoening/libhermit-rs/pull/8
- https://github.com/simonschoening/rusty-hermit/pull/2